### PR TITLE
A general interface to get and set logging level from ini

### DIFF
--- a/src/natlinkcore/configure/list of functions.txt
+++ b/src/natlinkcore/configure/list of functions.txt
@@ -27,8 +27,8 @@
 -v    enable_vocola(arg)
 -V    disable_vocola()
 
--x    enableDebugOutput
--X    disableDebugOutput
+-x    setLogging("DEBUG")
+-X    setLogging("CRITICAL")
 
 
 

--- a/src/natlinkcore/configure/nalinkgui.py
+++ b/src/natlinkcore/configure/nalinkgui.py
@@ -34,6 +34,7 @@ def collapse(layout, key, visible):
 # FIXME: Any text sg.Input/sg.I with enable_events=True will fire the event with every keystroke. 
     # This is a problem when editing the a path in the input field.
 natlink_section = [[sg.Text('Natlink', text_color='black')],
+                    [sg.T('Nalink Loglevel:'),  sg.Combo(default_value=Status.getLogging().title(), values=("Critical",  "Fatal",  "Error", "Warning", "Info" , "Debug"), key='Set_Logging_Natlink', enable_events=True, auto_size_text=True, readonly=True)],
                     [sg.I(Status.getUserDirectory(), key='Set_UserDir_Natlink',  tooltip=r'The directory where User Natlink grammar files are located (e.g., "~\UserDirectory")', enable_events=True), sg.FolderBrowse(), sg.B("Clear", key='Clear_UserDir_Natlink', enable_events=True)]]
 
 dragonfly_section = [[sg.Text('Dragonfly', text_color='black')],
@@ -53,8 +54,6 @@ autohotkey_section = [[sg.T('Autohotkey', text_color='black')],
 
 #### Main UI Layout ####
 layout = [[sg.T('Environment:', font='bold'), sg.T(f'Windows OS: {osVersion.major}, Build: {osVersion.build}'), sg.T(f'Python: {pyVersion}'), sg.T(f'Dragon Version: {Status.getDNSVersion()}')],
-          #### Nalink Logging####
-          [sg.T('Nalink:', font='bold'), sg.Checkbox('Enable Debug', key='Set_Debug_Natlink', enable_events=True)],
           #### Projects Checkbox ####
           [sg.T('Configure Projects:', font='bold')],
           [sg.Checkbox('Natlink', enable_events=True, key='natlink-checkbox'), sg.Checkbox('Dragonfly', enable_events=True, key='dragonfly-checkbox'), sg.Checkbox('Vocola', enable_events=True, key='vocola2-checkbox'), sg.Checkbox('Unimacro', enable_events=True, key='unimacro-checkbox'), sg.Checkbox('AutoHotkey', key='autohotkey-checkbox', enable_events=True)],
@@ -72,12 +71,7 @@ window = sg.Window('Natlink GUI', layout)
 ##### Config Functions #####
 # Natlink
 def SetNatlinkLoggingOutput(values, event):
-    #TODO: Handle other logging levels
-    if values['Set_Debug_Natlink']:
-        Config.enableDebugOutput()
-    else:
-        Config.disableDebugOutput()
-
+    Config.setLogging(values['Set_Logging_Natlink'])
 
 def NatlinkUserDir(values, event):
     if event.startswith('Set'):
@@ -144,7 +138,7 @@ def AhkUserDir(values, event):
 
 
 # Lookup dictionary that maps keys as events to a function to call in Event Loop.
-nalink_dispatch = {'Set_Debug_Natlink': SetNatlinkLoggingOutput, 'Set_UserDir_Natlink': NatlinkUserDir, 'Clear_UserDir_Natlink': NatlinkUserDir}
+nalink_dispatch = {'Set_Logging_Natlink': SetNatlinkLoggingOutput, 'Set_UserDir_Natlink': NatlinkUserDir, 'Clear_UserDir_Natlink': NatlinkUserDir}
 dragonfly_dispatch = {'Set_UserDir_Dragonfly': DragonflyUserDir, 'Clear_UserDir_Dragonfly': DragonflyUserDir}
 vocola_dispatch = {'Set_UserDir_Vocola': VocolaUserDir, 'Clear_UserDir_Vocola': VocolaUserDir,'Vocola_Lang': VocolaTakesLanguages,'Vocola_Unimacro_Actions': VocolaUnimacroActions}  # , 'Set_GrammarsDir_Vocola': VocolaGrammarsDir
 unimacro_dispatch = {'Set_UserDir_Unimacro': UnimacroUserDir, 'Clear_UserDir_Unimacro': UnimacroUserDir}

--- a/src/natlinkcore/configure/natlinkconfig_cli.py
+++ b/src/natlinkcore/configure/natlinkconfig_cli.py
@@ -303,11 +303,11 @@ In this VocolaUserDirectory your Vocola Command File are/will be located.
     def do_x(self, arg):
         self.message = 'Print debug output to "Messages from Natlink" window'
         print(f'do action: {self.message}')
-        self.Config.enableDebugOutput()
+        self.Config.setLogging("DEBUG")
     def do_X(self, arg):
         self.message = 'Disable printing debug output to "Messages from Natlink" window'
         print(f'do action: {self.message}')
-        self.Config.disableDebugOutput()
+        self.Config.setLogging("CRITICAL")
 
     def help_x(self):
         print('-'*60)

--- a/src/natlinkcore/configure/natlinkconfigfunctions.py
+++ b/src/natlinkcore/configure/natlinkconfigfunctions.py
@@ -241,6 +241,7 @@ class NatlinkConfig:
             print(f'setLogging, setting is already "{old_value}"')
             return True
         if value in ["CRITICAL", "FATAL", "ERROR", "WARNING", "INFO", "DEBUG"]:
+            print(f'setLogging, setting logging to: "{value}"')
             self.config_set('settings', "log_level", value)
             if old_value is not None:
                 self.config_set('previous settings', "log_level", old_value)

--- a/src/natlinkcore/configure/natlinkconfigfunctions.py
+++ b/src/natlinkcore/configure/natlinkconfigfunctions.py
@@ -231,36 +231,22 @@ class NatlinkConfig:
         print(f'cleared "{option}"')
   
 
-    def enableDebugOutput(self):
-        """setting registry key so debug output of loading of natlinkmain is given
-
+    def setLogging(self, logginglevel):
+        """Sets the natlink logging output
+        logginglevel (str) -- CRITICAL, FATAL, ERROR, WARNING, INFO, DEBUG
         """
-        key = "log_level"
-        settings = 'settings'
-        old_value = self.config_get(settings, key)
-        if old_value:
-            if old_value == 'DEBUG':
-                print(f'enableDebugOutput, setting is already "{old_value}"')
-                return True
+        value = logginglevel.upper()
+        old_value = self.config_get('settings', "log_level")
+        if old_value == value:
+            print(f'setLogging, setting is already "{old_value}"')
+            return True
+        if value in ["CRITICAL", "FATAL", "ERROR", "WARNING", "INFO", "DEBUG"]:
+            self.config_set('settings', "log_level", value)
             if old_value is not None:
-                self.config_set('previous settings', key, old_value)
-        self.config_set(settings, key, 'DEBUG')
-        return True
-
-    def disableDebugOutput(self):
-        """disables the Natlink debug output
-        """
-        key = 'log_level'
-        section = 'settings'
-        old_value = self.config_get('previous settings', key)
-        if old_value:
-            self.config.remove_option('previous settings', key)
-            if old_value == 'DEBUG':
-                old_value = 'INFO'
+                self.config_set('previous settings', "log_level", old_value)
+            return True
         else:
-            old_value = 'INFO'
-        self.config_set(section, key, old_value)
-        return True
+            print(f"setLogging: Logging Level {value} is not valid")
 
     def enable_unimacro(self, arg):
         unimacro_user_dir = self.status.getUnimacroUserDirectory()

--- a/src/natlinkcore/natlinkstatus.py
+++ b/src/natlinkcore/natlinkstatus.py
@@ -238,6 +238,15 @@ class NatlinkStatus(metaclass=singleton.Singleton):
         self.DNSIniDir = loader.get_config_info_from_registry("dragonIniDir")
         return self.DNSIniDir
 
+    def getLogging(self):
+        """Retuns the natlink logging output
+        """
+        key = 'log_level'
+        settings = 'settings'
+        value = self.natlinkmain.getconfigsetting(settings, key)
+        if value:
+            return value
+        return   
     
     def getDNSVersion(self):
         """find the correct DNS version number (as an integer)


### PR DESCRIPTION
setLogging sets the natlink logging output as CRITICAL, FATAL, ERROR, WARNING, INFO, DEBUG in ini
getLogging Retuns the natlink logging level from ini

replaces `disableDebugOutput` and `enableDebugOutput`