### PR TITLE
Add initial GitHub Actions

### DIFF
--- a/.github/workflows/python-lint-test.yml
+++ b/.github/workflows/python-lint-test.yml
@@ -25,14 +25,13 @@ jobs:
         python -m pip install flake8 pytest
     - name: Linting with flake8
       run: |
-        echo "CI linting not impplemmented"
+        echo "CI linting not implemented"
         # stop the build if there are Python syntax errors or undefined names
         #flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         #flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Running pytest tests
       run: |
-        # This assumes pytest is installed via the install-package step above
-        echo "CI tests not impplemmented"
+        echo "CI tests not implemented"
         # pip install -e .[test]  
         # pytest

--- a/.github/workflows/python-lint-test.yml
+++ b/.github/workflows/python-lint-test.yml
@@ -1,0 +1,38 @@
+name:  Python 🐛 Lint/Test
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  test:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10"]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install test dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8 pytest
+    - name: Linting with flake8
+      run: |
+        echo "CI linting not impplemmented"
+        # stop the build if there are Python syntax errors or undefined names
+        #flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        #flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Running pytest tests
+      run: |
+        # This assumes pytest is installed via the install-package step above
+        echo "CI tests not impplemmented"
+        # pip install -e .[test]  
+        # pytest

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,29 @@
+name: Publish Package 📦 to Test PyPI
+on:
+  release:
+    types: [published] # with prerelease and release
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    # Set up the environment `CI` references the secret `TEST_PYPI_API_TOKEN` in repository settings
+    # https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#referencing-an-environment
+    environment: CI
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Installing build Dependencies
+      run: |
+          python -m pip install --upgrade pip
+          python -m pip install flit
+    - name: Building package with flit
+      run: |
+            flit build
+    - name: Publishing 📦 to Test PyPI
+     # Regarding building artifacts within Platform specific environment see https://github.com/pypa/gh-action-pypi-publish#non-goals
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/


### PR DESCRIPTION
This PR sets up the basics for publishing packages and linting then running tests.
- The linting/tests action runs every push or PR. 
- Publishing python package only takes place upon a pre-release or release.

 Functionally linting and tests are disabled.  Tests are not ready to be run in the CI without the Natlink package and linting conventions are not yet agreed upon. Test PyPi left in for other members to test and can be easily updated to production PyPi.

PR is based on Doug's work in https://github.com/dictation-toolbox/natlinkcore/pull/20

Remember to set up the environment `CI` references the secret `TEST_PYPI_API_TOKEN` in repository settings. [Documentation](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#referencing-an-environment)
  