### PR TITLE
Fix dpi16activaterule

### DIFF
--- a/src/natlinkcore/SampleMacros/_sample_activatedeactivate.py
+++ b/src/natlinkcore/SampleMacros/_sample_activatedeactivate.py
@@ -1,0 +1,125 @@
+#
+# Python Macro Language for Dragon NaturallySpeaking
+#   (c) Copyright 1999 by Joel Gould
+#   Portions (c) Copyright 1999 by Dragon Systems, Inc.
+#
+#pylint:disable=C0115, C0116, W0613, W0201
+"""_sample_runmimic.py
+
+This script tests the commands of activating rules in interactive mode
+
+Januaryt 2024, with possible changes with DPI16.
+
+1. Load this file in one of your "directories"
+2. Toggle your microphone
+3. Say: "mimic runzero".
+
+
+
+
+
+
+"""
+# import natlink
+import copy
+from natlinkcore.natlinkutils import GrammarBase
+
+class ThisGrammar(GrammarBase):
+
+    gramSpec = """
+        <activaterule> exported = activate rule {rulelist};
+        <activateset> exported = activate set {setlist};
+        <activateall> exported = activate all;
+        <deactivaterule> exported = deactivate rule {rulelist};
+        <deactivateset> exported = deactivate set {setlist};
+        <deactivateall> exported = deactivate all;
+        <show> exported = show (results | "active rules");
+
+        <ruleone> exported = test rule one;
+        <ruletwo> exported = test rule two;
+        <rulethree> exported = test rule three;
+    """
+    
+    def initialize(self):
+        self.load(self.gramSpec)
+        self.setList('rulelist', ['one', 'two', 'three'])
+        self.setList('setlist', ['one', 'two'])
+        self.basicset = ['show', 'activateall', 'activaterule', 'activateset',
+                      'deactivateall','deactivaterule','deactivateset']
+        self.activateSet(self.basicset)
+        self.sets = {}
+        self.sets['setone'] = ['ruleone', 'rulethree']
+        self.sets['settwo'] = ['ruletwo', 'rulethree']
+
+    def gotResults_ruleone(self,words,fullResults):
+        print(f'\nHeard macro ruleone: "{words}"')
+    def gotResults_ruletwo(self,words,fullResults):
+        print(f'\nHeard macro ruletwo: "{words}"')
+    def gotResults_rulethree(self,words,fullResults):
+        print(f'\nHeard macro rulethree: "{words}"')
+    
+    def gotResults_activaterule(self,words,fullResults):
+        print(f'Heard macro activaterule "{words}"')
+        rulename = "rule" + words[-1]
+        self.activate(rulename)
+        self.show()
+
+    def gotResults_activateset(self,words,fullResults):
+        print(f'Heard macro activateset: "{words}"')
+        setname = "set" + words[-1]
+        self.activateSet(self.sets[setname] + self.basicset)
+        self.show()
+
+    def gotResults_activateall(self,words,fullResults):
+        print(f'Heard macro activateall: "{words}"')
+        self.activateAll()
+        self.show()
+
+    def gotResults_deactivaterule(self,words,fullResults):
+        print(f'Heard macro deactivaterule "{words}"')
+        rulename = "rule" + words[-1]
+        self.deactivate(rulename)
+        self.show()
+
+    def gotResults_deactivateset(self,words,fullResults):
+        print(f'Heard macro deactivateset "{words}"')
+        setname = "set" + words[-1]
+        self.deactivateSet(self.sets[setname])
+        self.show()
+        
+    def gotResults_deactivateall(self,words,fullResults):
+        print(f'Heard macro deactivateall: "{words}"')
+        self.deactivateAll()
+        print('all deactivated? {self.activeRules}')
+        self.activateSet(self.basicset)
+        print('now the basicset is set again')
+        self.show()
+        
+    def gotResults_show(self,words,fullResults):
+        print(f'Heard macro show: "{words}"')
+        print(f'activeRules: {self.activeRules}')
+    
+    def show(self):
+        """show the results
+        either with the command "show results" or after one
+        of the other commands
+        """
+        activedict = copy.copy(self.activeRules)
+        for rule in self.basicset:
+            if rule not in activedict:
+                print(f'basicrule {rule} NOT in activeRules')
+            else:
+                del activedict[rule]
+        print(f'active testrules: {list(activedict.keys())}')
+        
+        
+        
+thisGrammar = ThisGrammar()
+thisGrammar.initialize()
+
+def unload():
+    #pylint:disable=W0603
+    global thisGrammar
+    if thisGrammar:
+        thisGrammar.unload()
+    thisGrammar = None

--- a/src/natlinkcore/natlinkutils.py
+++ b/src/natlinkcore/natlinkutils.py
@@ -736,7 +736,7 @@ to save space.)
                 print(f'set exclusive mode to {exclusive} for rule "{ruleName}"')
             self.setExclusive(exclusive)
 
-    def deactivate(self, ruleName, noError=0):
+    def deactivate(self, ruleName, noError=0, dpi16trick=False):
         #pylint:disable=W0221
         if ruleName not in self.validRules:
             if noError:
@@ -748,6 +748,14 @@ to save space.)
             raise ValueError( "rule %s is not active (activeRules: %s)"% (ruleName, self.activeRules))
         if debugLoad:
             print('deactivate rule %s'% ruleName)
+        if dpi16trick:
+            # now deactivate  all and activate other rules again
+            # be sure, this one is not called recursive!!
+            active_rules = copy.copy(self.activeRules)
+            del active_rules[ruleName]
+            self.deactivateAll()
+            self.activateSet(list(active_rules.keys()))
+            return
         self.gramObj.deactivate(ruleName)
         del self.activeRules[ruleName]
 


### PR DESCRIPTION
I think this is the fix for the activate/deactivate problem that arose in DPI16.

Basic trick: deactivate all rules and activate the one that are needed again. When you set the debugLoad option in natlinkutils.py to 1, you will get the debug information. (line 50).

Demo grammar file in samplemacros directory, see image (_sample_activatedeactivate.py) some explanation at the top of the file...

I think, I can release this.

![fix activate deactivate2024-01-27](https://github.com/dictation-toolbox/natlinkcore/assets/21167695/70f24693-dbc5-4d7d-81fa-314e0b56cb32)
