### PR TITLE
Use named loggers instead of setting root logger in natlinkcore library

### DIFF
--- a/src/natlinkcore/loader.py
+++ b/src/natlinkcore/loader.py
@@ -667,7 +667,7 @@ def startDap(config : NatlinkConfig) -> bool:
 
 
 def run() -> None:
-    default_logger=logging.getLogger()
+    default_logger=logging.getLogger("natlink")
     dh = OutputDebugStringHandler()
     sh=logging.StreamHandler(sys.stdout)
     for h in [sh,dh]:
@@ -688,7 +688,7 @@ def run() -> None:
         config = NatlinkConfig.from_first_found_file(config_locations())
     
         dap_started = config.dap_enabled and startDap(config)           
-        logger=logging.getLogger("natlink")
+        logger=logging.getLogger("natlinkcore")
         logger.setLevel(logging.DEBUG)
 
         main = NatlinkMain(logger, config)


### PR DESCRIPTION
This pr use named loggers instead of setting root logger in natlinkcore library. Fixing https://github.com/dictation-toolbox/natlinkcore/issues/71

Changes to `loader.py`

https://github.com/dictation-toolbox/natlinkcore/blob/2dd7df495cff67dc05e786666d268dfaa18763b1/src/natlinkcore/loader.py#L669-L699

- 'OutputDebugStringHandler' is from natlink there for logger is named `natlink` instead setting the root logger. If natlinkcore main fails to loads this logger should catch it.
-  Rename `natlink` to `natlinkcore` as the is loading `natlinkcore` after NatlinkConfig. 
https://github.com/dictation-toolbox/natlinkcore/blob/2dd7df495cff67dc05e786666d268dfaa18763b1/src/natlinkcore/loader.py#L691
