### PR TITLE
Migrate from PySimpleGUI to FreeSimpleGUI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.9"
 readme = "readme.md"
 dependencies= [
 ##  "natlink>=5.3.4",
-    "pysimplegui>=4.60.3", 
+    "FreeSimpleGUI>=5.1.0", 
     "pydebugstring >= 1.0.0.1",
     "dtactions>=1.6.1",
     "platformdirs >= 4.2.0"

--- a/src/natlinkcore/__init__.py
+++ b/src/natlinkcore/__init__.py
@@ -1,6 +1,6 @@
 '''Python portion of Natlink, a compatibility module for Dragon Naturally Speaking
 The python stuff including test modules'''
-__version__="5.3.12"
+__version__="5.3.13"
 #pylint:disable=
 from pathlib import Path
 

--- a/src/natlinkcore/configure/natlinkconfig_gui.py
+++ b/src/natlinkcore/configure/natlinkconfig_gui.py
@@ -2,7 +2,7 @@
 import sys
 import platform
 
-import PySimpleGUI as sg
+import FreeSimpleGUI as sg
 import logging
 from platformdirs import  user_log_dir
 from pathlib import Path


### PR DESCRIPTION
FreeSimpleGUI is a dropin replacement for PySimpleGUI. PySimpleGUI now requires a (paid) license. The licensing does not support open source developers use of PySimpleGUI for non profit. PySimpleGUI was forked to FreeSimpleGUI and removed licensing. 